### PR TITLE
Just corrects 'translatior' to 'translator'

### DIFF
--- a/db/migrate/20220927210617_correct_spelling_of_translator.rb
+++ b/db/migrate/20220927210617_correct_spelling_of_translator.rb
@@ -1,0 +1,5 @@
+class CorrectSpellingOfTranslator < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :authorships, :translatior, :translator
+  end
+end


### PR DESCRIPTION
No idea how this was missed for so long, but in the original migration to create the authorships, translator was spelled as 'translatior' As I'm setting this up with docker, I'm finding a few odd details like this.