### PR TITLE
Looking to debug the web-console for debugging...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'wikipedia-client'
 
 group :development, :test do
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bindex (0.8.1)
     bluecloth (2.2.0)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
@@ -277,6 +278,11 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.4.2)
+    web-console (4.2.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -319,6 +325,7 @@ DEPENDENCIES
   test-unit
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
+  web-console
   wikipedia-client
 
 BUNDLED WITH

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -101,6 +101,7 @@ class BooksController < ApplicationController
   end
 
   def unread
+    raise FooBar
     @books = Book.unread_books
     @fruit = Book.low_hanging_fruit
     @page_title = 'Unread Books'

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module RailsPortal
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
+    # The allowed IP may change based on whether or not the development host
+    # is in docker on on another linux host.
+    config.web_console.permissions = '172.28.0.0/16'
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,43 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+threads min_threads_count, max_threads_count
+
+# Specifies the `worker_timeout` threshold that Puma will use to wait before
+# terminating a worker in development environments.
+#
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
+
+# Allow puma to be restarted by `bin/rails restart` command.
+plugin :tmp_restart


### PR DESCRIPTION
Web-Console works on Linux Local host (security allows requests from 127.0.0.1, apparently...)

Web-Console works with the Docker version, so long as the IP/CIDR happens to match what we've seen before. 

This revision introduces the puma plug-in for touch tmp/restart.txt. This works just fine on the Linux host but will fail in the windows Docker version consistently with Error 127. It looks like this is connected to a \r somewhere in the files, but I haven't been able to run that to ground yet, even after running utilities like dos2unix to change line endings.