### PR TITLE
Removes raise Foobar in books#unread

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -101,7 +101,6 @@ class BooksController < ApplicationController
   end
 
   def unread
-    raise FooBar
     @books = Book.unread_books
     @fruit = Book.low_hanging_fruit
     @page_title = 'Unread Books'


### PR DESCRIPTION
Just removes the raise Foobar used in debugging the addition of the webconsole gem.

Everything else works as per normal. I added the raise in the books#unread action to assure that a webconsole would be available.