### PR TITLE
Update Dockerfile to use ruby 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1
-FROM ruby:2.7.0
+FROM ruby:3.0.0
 
 RUN apt update && apt install -y \
 	build-essential \


### PR DESCRIPTION
Updates the pulled version of ruby to 3.0.0 since recent security changes (nokogiri) required a move to ruby 3.0.0. Linux native doesn't require this change but having the version pinned in the dockerfile makes sense.