### PR TITLE
Just adds a count of finished books to the front page.

### DIFF
--- a/app/views/books/index.html.haml
+++ b/app/views/books/index.html.haml
@@ -40,9 +40,12 @@
 	-if @last_read
 		#last_read
 			%h3 Latest Read Books:
+			%p #{@last_read.count} books completed in the last 12 months:
+			%ol
 			-@last_read.each do |read|
-				%h5=link_to read.title, read
-				%p.small Completed #{read.date_finished.strftime('%B %-d, %Y')}
+				%li
+					%h5=link_to read.title, read
+					%p.small Completed #{read.date_finished.strftime('%B %-d, %Y')}
 	
 	-if @prolific_authors
 		#prolific_authors


### PR DESCRIPTION
Dirt simple, just adds the count of finished books from the past 12 months. Reuse the @last_read and spit out the .count.

Re-formats the list of finished titles as an actual list, since, you know, it's a list and all that...