### PR TITLE
fix longstanding bug with just displaying the lanuage_id on the book#show page

### DIFF
--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -52,7 +52,7 @@
 -# maybe what is used for the pie-graph on the front page could be helpful
 %p
   %strong Original Language:
-  #{@book.original_language}
+  #{Language.find(@book.original_language).name}
 
 %p 
   %strong Last Modified:


### PR DESCRIPTION
Just makes the original language on the books#show spell it out rather than us the number.

New code does a lookup on the Language model by the ID. Probably shouldn't happen in the view layer, but it works.