### PR TITLE
Just bumps the Gemfile.lock for the new version of rexml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
     regexp_parser (2.8.1)
     reline (0.5.9)
       io-console (~> 0.5)
-    rexml (3.2.5)
+    rexml (3.3.8)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)


### PR DESCRIPTION
Up to version 3.2.8 to resolve a dependabot-flagged problem.